### PR TITLE
add custom fs to editor.open

### DIFF
--- a/test/SourceKit/Inputs/vfs/CModule/CModule.h
+++ b/test/SourceKit/Inputs/vfs/CModule/CModule.h
@@ -1,3 +1,5 @@
 struct StructDefinedInCModule {
   int intFieldDefinedInCModule;
 };
+
+void functionDefinedInCModule();

--- a/test/SourceKit/Sema/injected_vfs.swift
+++ b/test/SourceKit/Sema/injected_vfs.swift
@@ -1,0 +1,22 @@
+import CModule
+import SwiftModule
+
+func foo(
+    _ structDefinedInSwiftModule: StructDefinedInSwiftModule,
+    _ structDefinedInSameTarget: StructDefinedInSameTarget
+) {
+    let a: String = functionDefinedInCModule()
+    // CHECK: cannot convert value of type 'Void' to specified type 'String'
+
+    let b: Float = structDefinedInSwiftModule.methodDefinedInSwiftModule()
+    // CHECK: cannot convert value of type '()' to specified type 'Float'
+
+    let c: Double = structDefinedInSameTarget.methodDefinedInSameTarget()
+    // CHECK: cannot convert value of type '()' to specified type 'Double'
+}
+
+// RUN: %empty-directory(%t)
+// RUN: %swift -emit-module -o %t/SwiftModule.swiftmodule -module-name SwiftModule %S/../Inputs/vfs/SwiftModule/SwiftModule.swift
+// RUN: %sourcekitd-test -req=open -vfs-files=/target_file1.swift=%s,/target_file2.swift=%S/../Inputs/vfs/other_file_in_target.swift,/CModule/module.modulemap=%S/../Inputs/vfs/CModule/module.modulemap,/CModule/CModule.h=%S/../Inputs/vfs/CModule/CModule.h,/SwiftModule/SwiftModule.swiftmodule=%t/SwiftModule.swiftmodule /target_file1.swift -- /target_file1.swift /target_file2.swift -I /CModule -I /SwiftModule == \
+// RUN:    -req=edit -pos=3:1 -replace="//" -length=0 /target_file1.swift == \
+// RUN:    -req=print-diags %s | %FileCheck %s

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -614,9 +614,10 @@ public:
   virtual void
   codeCompleteSetCustom(ArrayRef<CustomCompletionInfo> completions) = 0;
 
-  virtual void editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
-                          EditorConsumer &Consumer,
-                          ArrayRef<const char *> Args) = 0;
+  virtual void
+  editorOpen(StringRef Name, llvm::MemoryBuffer *Buf, EditorConsumer &Consumer,
+             ArrayRef<const char *> Args,
+             llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem) = 0;
 
   virtual void editorOpenInterface(EditorConsumer &Consumer,
                                    StringRef Name,

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -77,11 +77,15 @@ struct InvocationOptions {
   const std::string PrimaryFile;
   const CompilerInvocation Invok;
 
+  /// If defined, all filesystem operations resulting from this invocation
+  /// should use this filesystem instead of the real filesystem.
+  const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem;
+
   InvocationOptions(ArrayRef<const char *> CArgs, StringRef PrimaryFile,
-                    CompilerInvocation Invok)
-    : Args(_convertArgs(CArgs)),
-      PrimaryFile(PrimaryFile),
-      Invok(std::move(Invok)) {
+                    CompilerInvocation Invok,
+                    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem)
+      : Args(_convertArgs(CArgs)), PrimaryFile(PrimaryFile),
+        Invok(std::move(Invok)), FileSystem(FileSystem) {
     // Assert invocation with a primary file. We want to avoid full typechecking
     // for all files.
     assert(!this->PrimaryFile.empty());
@@ -163,6 +167,7 @@ void InvocationOptions::profile(llvm::FoldingSetNodeID &ID) const {
   for (auto &Arg : Args)
     ID.AddString(Arg);
   ID.AddString(PrimaryFile);
+  ID.AddPointer(FileSystem.get());
 }
 
 //===----------------------------------------------------------------------===//
@@ -364,11 +369,15 @@ struct SwiftASTManager::Implementation {
                            "sourcekit.swift.ASTBuilding" };
 
   ASTProducerRef getASTProducer(SwiftInvocationRef InvokRef);
-  FileContent getFileContent(StringRef FilePath, bool IsPrimary,
-                             std::string &Error);
-  BufferStamp getBufferStamp(StringRef FilePath);
-  std::unique_ptr<llvm::MemoryBuffer> getMemoryBuffer(StringRef Filename,
-                                                      std::string &Error);
+  FileContent
+  getFileContent(StringRef FilePath, bool IsPrimary, std::string &Error,
+                 llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem);
+  BufferStamp
+  getBufferStamp(StringRef FilePath,
+                 llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem);
+  std::unique_ptr<llvm::MemoryBuffer> getMemoryBuffer(
+      StringRef Filename, std::string &Error,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem = nullptr);
 };
 
 SwiftASTManager::SwiftASTManager(
@@ -532,17 +541,17 @@ bool SwiftASTManager::initCompilerInvocationNoInputs(
   return false;
 }
 
-SwiftInvocationRef
-SwiftASTManager::getInvocation(ArrayRef<const char *> OrigArgs,
-                               StringRef PrimaryFile,
-                               std::string &Error) {
+SwiftInvocationRef SwiftASTManager::getInvocation(
+    ArrayRef<const char *> OrigArgs, StringRef PrimaryFile, std::string &Error,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem) {
 
   DiagnosticEngine Diags(Impl.SourceMgr);
   EditorDiagConsumer CollectDiagConsumer;
   Diags.addConsumer(CollectDiagConsumer);
 
   CompilerInvocation CompInvok;
-  if (initCompilerInvocation(CompInvok, OrigArgs, Diags, PrimaryFile, Error)) {
+  if (initCompilerInvocation(CompInvok, OrigArgs, Diags, PrimaryFile, Error,
+                             FileSystem)) {
     // We create a traced operation here to represent the failure to parse
     // arguments since we cannot reach `createAST` where that would normally
     // happen.
@@ -559,7 +568,7 @@ SwiftASTManager::getInvocation(ArrayRef<const char *> OrigArgs,
     return nullptr;
   }
 
-  InvocationOptions Opts(OrigArgs, PrimaryFile, CompInvok);
+  InvocationOptions Opts(OrigArgs, PrimaryFile, CompInvok, FileSystem);
   return new SwiftInvocation(
       *new SwiftInvocation::Implementation(std::move(Opts)));
 }
@@ -625,38 +634,45 @@ static FileContent getFileContentFromSnap(ImmutableTextSnapshotRef Snap,
 }
 
 FileContent SwiftASTManager::Implementation::getFileContent(
-    StringRef UnresolvedPath, bool IsPrimary, std::string &Error) {
+    StringRef UnresolvedPath, bool IsPrimary, std::string &Error,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem) {
   std::string FilePath = SwiftLangSupport::resolvePathSymlinks(UnresolvedPath);
   if (auto EditorDoc = EditorDocs->findByPath(FilePath))
     return getFileContentFromSnap(EditorDoc->getLatestSnapshot(), IsPrimary,
                                   FilePath);
 
   // FIXME: Is there a way to get timestamp and buffer for a file atomically ?
-  auto Stamp = getBufferStamp(FilePath);
-  auto Buffer = getMemoryBuffer(FilePath, Error);
+  auto Stamp = getBufferStamp(FilePath, FileSystem);
+  auto Buffer = getMemoryBuffer(FilePath, Error, FileSystem);
   return FileContent(nullptr, UnresolvedPath, std::move(Buffer), IsPrimary,
                      Stamp);
 }
 
-BufferStamp SwiftASTManager::Implementation::getBufferStamp(StringRef FilePath){
+BufferStamp SwiftASTManager::Implementation::getBufferStamp(
+    StringRef FilePath,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem) {
   if (auto EditorDoc = EditorDocs->findByPath(FilePath))
     return EditorDoc->getLatestSnapshot()->getStamp();
 
-  llvm::sys::fs::file_status Status;
-  if (std::error_code Ret = llvm::sys::fs::status(FilePath, Status)) {
+  auto StatusOrErr = FileSystem
+                         ? FileSystem->status(FilePath)
+                         : llvm::vfs::getRealFileSystem()->status(FilePath);
+  if (std::error_code Err = StatusOrErr.getError()) {
     // Failure to read the file.
-    LOG_WARN_FUNC("failed to stat file: " << FilePath
-                  << " (" << Ret.message() << ')');
+    LOG_WARN_FUNC("failed to stat file: " << FilePath << " (" << Err.message()
+                                          << ')');
     return -1;
   }
-  return Status.getLastModificationTime().time_since_epoch().count();
+  return StatusOrErr.get().getLastModificationTime().time_since_epoch().count();
 }
 
 std::unique_ptr<llvm::MemoryBuffer>
-SwiftASTManager::Implementation::getMemoryBuffer(StringRef Filename,
-                                                 std::string &Error) {
+SwiftASTManager::Implementation::getMemoryBuffer(
+    StringRef Filename, std::string &Error,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem) {
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-    llvm::MemoryBuffer::getFile(Filename);
+      FileSystem ? FileSystem->getBufferForFile(Filename)
+                 : llvm::vfs::getRealFileSystem()->getBufferForFile(Filename);
   if (FileBufOrErr)
     return std::move(FileBufOrErr.get());
 
@@ -771,7 +787,8 @@ bool ASTProducer::shouldRebuild(SwiftASTManager::Implementation &MgrImpl,
       }
     }
     if (!FoundSnapshot)
-      InputStamps.push_back(MgrImpl.getBufferStamp(File));
+      InputStamps.push_back(
+          MgrImpl.getBufferStamp(File, Invok.Opts.FileSystem));
   }
   assert(InputStamps.size() ==
          Invok.Opts.Invok.getFrontendOptions().InputsAndOutputs.inputCount());
@@ -779,7 +796,8 @@ bool ASTProducer::shouldRebuild(SwiftASTManager::Implementation &MgrImpl,
     return true;
 
   for (auto &Dependency : DependencyStamps) {
-    if (Dependency.second != MgrImpl.getBufferStamp(Dependency.first))
+    if (Dependency.second !=
+        MgrImpl.getBufferStamp(Dependency.first, Invok.Opts.FileSystem))
       return true;
   }
 
@@ -886,7 +904,7 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
 
   Invocation.getLangOptions().CollectParsedToken = true;
 
-  if (CompIns.setup(Invocation)) {
+  if (CompIns.setup(Invocation, InvokRef->Impl.Opts.FileSystem)) {
     // FIXME: Report the diagnostic.
     LOG_WARN_FUNC("Compilation setup failed!!!");
     Error = "compilation setup failed";
@@ -908,8 +926,9 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
   // FIXME: There exists a small window where the module file may have been
   // modified after compilation finished and before we get its stamp.
   for (auto &Filename : Filenames) {
-    DependencyStamps.push_back(std::make_pair(Filename,
-                                              MgrImpl.getBufferStamp(Filename)));
+    DependencyStamps.push_back(std::make_pair(
+        Filename,
+        MgrImpl.getBufferStamp(Filename, InvokRef->Impl.Opts.FileSystem)));
   }
 
   // Since we only typecheck the primary file (plus referenced constructs
@@ -961,7 +980,8 @@ void ASTProducer::findSnapshotAndOpenFiles(
     if (FoundSnapshot)
       continue;
 
-    auto Content = MgrImpl.getFileContent(File, IsPrimary, Error);
+    auto Content =
+        MgrImpl.getFileContent(File, IsPrimary, Error, Opts.FileSystem);
     if (!Content.Buffer) {
       LOG_WARN_FUNC("failed getting file contents for " << File << ": "
                                                         << Error);

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -93,9 +93,9 @@ public:
                            StringRef RuntimeResourcePath);
   ~SwiftASTManager();
 
-  SwiftInvocationRef getInvocation(ArrayRef<const char *> Args,
-                                   StringRef PrimaryFile,
-                                   std::string &Error);
+  SwiftInvocationRef getInvocation(
+      ArrayRef<const char *> Args, StringRef PrimaryFile, std::string &Error,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem = nullptr);
 
   /// Provides the AST associated with an invocation to the AST consumer,
   /// asynchronously.

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -623,9 +623,12 @@ public:
 
   uint64_t getASTGeneration() const;
 
-  void setCompilerArgs(ArrayRef<const char *> Args) {
+  void
+  setCompilerArgs(ArrayRef<const char *> Args,
+                  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem) {
     if (auto ASTMgr = this->ASTMgr.lock()) {
-      InvokRef = ASTMgr->getInvocation(Args, Filename, CompilerArgsError);
+      InvokRef =
+          ASTMgr->getInvocation(Args, Filename, CompilerArgsError, FileSystem);
     }
   }
 
@@ -1682,7 +1685,8 @@ SwiftEditorDocument::~SwiftEditorDocument()
 
 ImmutableTextSnapshotRef SwiftEditorDocument::initializeText(
     llvm::MemoryBuffer *Buf, ArrayRef<const char *> Args,
-    bool ProvideSemanticInfo) {
+    bool ProvideSemanticInfo,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem) {
 
   llvm::sys::ScopedLock L(Impl.AccessMtx);
 
@@ -1699,7 +1703,7 @@ ImmutableTextSnapshotRef SwiftEditorDocument::initializeText(
   if (ProvideSemanticInfo || !Args.empty()) {
     Impl.SemanticInfo = new SwiftDocumentSemanticInfo(Impl.FilePath, Impl.ASTMgr,
                                                       Impl.NotificationCtr);
-    Impl.SemanticInfo->setCompilerArgs(Args);
+    Impl.SemanticInfo->setCompilerArgs(Args, FileSystem);
   }
   return Impl.EditableBuffer->getSnapshot();
 }
@@ -2094,15 +2098,17 @@ void SwiftEditorDocument::reportDocumentStructure(SourceFile &SrcFile,
 // EditorOpen
 //===----------------------------------------------------------------------===//
 
-void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
-                                  EditorConsumer &Consumer,
-                                  ArrayRef<const char *> Args) {
+void SwiftLangSupport::editorOpen(
+    StringRef Name, llvm::MemoryBuffer *Buf, EditorConsumer &Consumer,
+    ArrayRef<const char *> Args,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem) {
 
   ImmutableTextSnapshotRef Snapshot = nullptr;
   auto EditorDoc = EditorDocuments->getByUnresolvedName(Name);
   if (!EditorDoc) {
     EditorDoc = new SwiftEditorDocument(Name, *this);
-    Snapshot = EditorDoc->initializeText(Buf, Args, Consumer.needsSemanticInfo());
+    Snapshot = EditorDoc->initializeText(
+        Buf, Args, Consumer.needsSemanticInfo(), FileSystem);
     EditorDoc->parse(Snapshot, *this, Consumer.syntaxTreeEnabled());
     if (EditorDocuments->getOrUpdate(Name, *this, EditorDoc)) {
       // Document already exists, re-initialize it. This should only happen
@@ -2115,7 +2121,8 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
   }
 
   if (!Snapshot) {
-    Snapshot = EditorDoc->initializeText(Buf, Args, Consumer.needsSemanticInfo());
+    Snapshot = EditorDoc->initializeText(
+        Buf, Args, Consumer.needsSemanticInfo(), FileSystem);
     EditorDoc->parse(Snapshot, *this, Consumer.syntaxTreeEnabled());
   }
 
@@ -2133,7 +2140,6 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
                               ReusedNodeIds);
   }
 }
-
 
 //===----------------------------------------------------------------------===//
 // EditorClose

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -88,9 +88,10 @@ public:
        swift::ide::CodeFormatOptions Options = swift::ide::CodeFormatOptions());
   ~SwiftEditorDocument();
 
-  ImmutableTextSnapshotRef initializeText(llvm::MemoryBuffer *Buf,
-                                          ArrayRef<const char *> Args,
-                                          bool ProvideSemanticInfo);
+  ImmutableTextSnapshotRef
+  initializeText(llvm::MemoryBuffer *Buf, ArrayRef<const char *> Args,
+                 bool ProvideSemanticInfo,
+                 llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem);
   ImmutableTextSnapshotRef replaceText(unsigned Offset, unsigned Length,
                                        llvm::MemoryBuffer *Buf,
                                        bool ProvideSemanticInfo,
@@ -437,9 +438,10 @@ public:
   void
   codeCompleteSetCustom(ArrayRef<CustomCompletionInfo> completions) override;
 
-  void editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
-                  EditorConsumer &Consumer,
-                  ArrayRef<const char *> Args) override;
+  void editorOpen(
+      StringRef Name, llvm::MemoryBuffer *Buf, EditorConsumer &Consumer,
+      ArrayRef<const char *> Args,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem) override;
 
   void editorOpenInterface(EditorConsumer &Consumer,
                            StringRef Name,


### PR DESCRIPTION
Proof-of-concept extending https://github.com/apple/swift/pull/24417 to "editor.open".

I wanted to make sure that custom filesystems would work with this "harder case". https://github.com/apple/swift/pull/24417 sets up a custom filesystem for code completion, which happens in a very straightforward way. "editor.open" is harder because it sets some state and then triggers an asynchronous task that reads the state and compiles based on that.

The main idea is that an "editor.open" request that comes with a filesystem sets the `EditorDoc`'s `InvocationOptions.FileSystem` to the given filesystem, and then all subsequent tasks related to that file read from that filesystem.

This idea seems to work. The test demonstrates that the diags from the async compilation task come back as expected.